### PR TITLE
Update Movie_recommendations.ipynb

### DIFF
--- a/pyg2neo/Movie_recommendations.ipynb
+++ b/pyg2neo/Movie_recommendations.ipynb
@@ -1278,7 +1278,7 @@
       },
       "outputs": [],
       "source": [
-        "weight = torch.bincount(train_data['user', 'movie'].edge_label)\n",
+        "weight = torch.bincount(train_data['user','rates', 'movie'].edge_label)\n",
         "weight = weight.max() / weight\n",
         "\n",
         "def weighted_mse_loss(pred, target, weight=None):\n",


### PR DESCRIPTION
fix for: `TypeError: HeteroData.get_edge_store() missing 1 required positional argument: 'dst'` in `weight = torch.bincount(train_data['user', 'movie'].edge_label)`


---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[48], line 1
----> 1 weight = torch.bincount(train_data['user', 'movie'].edge_label)
      2 weight = weight.max() / weight
      4 def weighted_mse_loss(pred, target, weight=None):

File ~/TorchStudio/python/envs/pyg/lib/python3.10/site-packages/torch_geometric/data/hetero_data.py:164, in HeteroData.__getitem__(self, *args)
    161     return out
    163 if isinstance(key, tuple):
--> 164     return self.get_edge_store(*key)
    165 else:
    166     return self.get_node_store(key)

TypeError: HeteroData.get_edge_store() missing 1 required positional argument: 'dst'